### PR TITLE
Only allow 'unique' and 'well-known' symbols

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -82,7 +82,7 @@ contributors:
       1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
       1. Let _entries_ be the List that is _M_.[[WeakMapData]].
       1. <del>If Type(_key_) is not Object, return *false*.</del>
-      1. <ins>If ! CanBeHeldWeakly(_key_) is *false*, return *false*.</ins>
+      1. <ins>If CanBeHeldWeakly(_key_) is *false*, return *false*.</ins>
       1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
         1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, then
           1. Set _p_.[[Key]] to ~empty~.
@@ -100,7 +100,7 @@ contributors:
       1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
       1. Let _entries_ be the List that is _M_.[[WeakMapData]].
       1. <del>If Type(_key_) is not Object, return *undefined*.</del>
-      1. <ins>If ! CanBeHeldWeakly(_key_) is *false*, return *undefined*.</ins>
+      1. <ins>If CanBeHeldWeakly(_key_) is *false*, return *undefined*.</ins>
       1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
         1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, return _p_.[[Value]].
       1. Return *undefined*.
@@ -115,7 +115,7 @@ contributors:
       1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
       1. Let _entries_ be the List that is _M_.[[WeakMapData]].
       1. <del>If Type(_key_) is not Object, return *false*.</del>
-      1. <ins>If ! CanBeHeldWeakly(_key_) is *false*, return *false*.</ins>
+      1. <ins>If CanBeHeldWeakly(_key_) is *false*, return *false*.</ins>
       1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
         1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, return *true*.
       1. Return *false*.
@@ -130,7 +130,7 @@ contributors:
       1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
       1. Let _entries_ be the List that is _M_.[[WeakMapData]].
       1. <del>If Type(_key_) is not Object, throw a *TypeError* exception.</del>
-      1. <ins>If ! CanBeHeldWeakly(_key_) is *false*, throw a *TypeError* exception.</ins>
+      1. <ins>If CanBeHeldWeakly(_key_) is *false*, throw a *TypeError* exception.</ins>
       1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
         1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, then
           1. Set _p_.[[Value]] to _value_.
@@ -152,7 +152,7 @@ contributors:
       1. Let _S_ be the *this* value.
       1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
       1. <del>If Type(_value_) is not Object, throw a *TypeError* exception.</del>
-      1. <ins>If ! CanBeHeldWeakly(_value_) is *false*, throw a *TypeError* exception.</ins>
+      1. <ins>If CanBeHeldWeakly(_value_) is *false*, throw a *TypeError* exception.</ins>
       1. Let _entries_ be the List that is _S_.[[WeakSetData]].
       1. For each element _e_ of _entries_, do
         1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, then
@@ -169,7 +169,7 @@ contributors:
       1. Let _S_ be the *this* value.
       1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
       1. <del>If Type(_value_) is not Object, return *false*.</del>
-      1. <ins>If ! CanBeHeldWeakly(_value_) is *false*, return *false*.</ins>
+      1. <ins>If CanBeHeldWeakly(_value_) is *false*, return *false*.</ins>
       1. Let _entries_ be the List that is _S_.[[WeakSetData]].
       1. For each element _e_ of _entries_, do
         1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, then
@@ -187,7 +187,7 @@ contributors:
       1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
       1. Let _entries_ be the List that is _S_.[[WeakSetData]].
       1. <del>If Type(_value_) is not Object, return *false*.</del>
-      1. <ins>If ! CanBeHeldWeakly(_value_) is *false*, return *false*.</ins>
+      1. <ins>If CanBeHeldWeakly(_value_) is *false*, return *false*.</ins>
       1. For each element _e_ of _entries_, do
         1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, return *true*.
       1. Return *false*.
@@ -204,7 +204,7 @@ contributors:
     <emu-alg>
       1. If NewTarget is *undefined*, throw a *TypeError* exception.
       1. <del>If Type(_target_) is not Object, throw a *TypeError* exception.</del>
-      1. <ins>If ! CanBeHeldWeakly(_target_) is *false*, throw a *TypeError* exception.</ins>
+      1. <ins>If CanBeHeldWeakly(_target_) is *false*, throw a *TypeError* exception.</ins>
       1. Let _weakRef_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%WeakRef.prototype%"*, &laquo; [[WeakRefTarget]] &raquo;).
       1. Perform ! AddToKeptObjects(_target_).
       1. Set _weakRef_.[[WeakRefTarget]] to _target_.
@@ -219,10 +219,10 @@ contributors:
       1. Let _finalizationRegistry_ be the *this* value.
       1. Perform ? RequireInternalSlot(_finalizationRegistry_, [[Cells]]).
       1. <del>If Type(_target_) is not Object, throw a *TypeError* exception.</del>
-      1. <ins>If ! CanBeHeldWeakly(_target_) is *false*, throw a *TypeError* exception.</ins>
+      1. <ins>If CanBeHeldWeakly(_target_) is *false*, throw a *TypeError* exception.</ins>
       1. If SameValue(_target_, _heldValue_) is *true*, throw a *TypeError* exception.
       1. <del>If Type(_unregisterToken_) is not Object, then</del>
-      1. <ins>If ! CanBeHeldWeakly(_unregisterToken_) is *false*, then</ins>
+      1. <ins>If CanBeHeldWeakly(_unregisterToken_) is *false*, then</ins>
         1. If _unregisterToken_ is not *undefined*, throw a *TypeError* exception.
         1. Set _unregisterToken_ to ~empty~.
       1. Let _cell_ be the Record { [[WeakRefTarget]]: _target_, [[HeldValue]]: _heldValue_, [[UnregisterToken]]: _unregisterToken_ }.
@@ -238,7 +238,7 @@ contributors:
       1. Let _finalizationRegistry_ be the *this* value.
       1. Perform ? RequireInternalSlot(_finalizationRegistry_, [[Cells]]).
       1. <del>If Type(_unregisterToken_) is not Object, throw a *TypeError* exception.</del>
-      1. <ins>If ! CanBeHeldWeakly(_unregisterToken_) is *false*, throw a *TypeError* exception.</ins>
+      1. <ins>If CanBeHeldWeakly(_unregisterToken_) is *false*, throw a *TypeError* exception.</ins>
       1. Let _removed_ be *false*.
       1. For each Record { [[WeakRefTarget]], [[HeldValue]], [[UnregisterToken]] } _cell_ of _finalizationRegistry_.[[Cells]], do
         1. If _cell_.[[UnregisterToken]] is not ~empty~ and SameValue(_cell_.[[UnregisterToken]], _unregisterToken_) is *true*, then

--- a/spec.emu
+++ b/spec.emu
@@ -16,40 +16,38 @@ contributors:
   - Ashley Claymore
 </pre>
 
-<emu-clause id="sec-ecmascript-data-types-and-values" aoid="Type">
-  <h1>ECMAScript Data Types and Values</h1>
-  <emu-clause id="sec-object-type">
-    <h1>The Object Type</h1>
-    <emu-clause id="sec-well-known-intrinsic-objects">
-      <h1>Well-Known Intrinsic Objects</h1>
-      <emu-table id="table-well-known-intrinsic-objects" caption="Well-Known Intrinsic Objects" oldids="table-7">
-        <table>
-          <tr>
-            <th>
-              Intrinsic Name
-            </th>
-            <th>
-              Global Name
-            </th>
-            <th>
-              ECMAScript Language Association
-            </th>
-          </tr>
-          <tr>
-            <td>
-              <ins>%CanBeHeldWeakly%</ins>
-            </td>
-            <td>
-            </td>
-            <td>
-              <ins>A function to check if a value can be held weakly (<emu-xref href="#sec-%canbeheldweakly%"></emu-xref>)</ins>
-            </td>
-          </tr>
-        </table>
-      </emu-table>
-    </emu-clause>
+<emu-clause id="sec-executable-code-and-execution-contexts">
+  <h1>Executable Code and Execution Contexts</h1>
+
+  <emu-clause id="sec-weakref-processing-model">
+    <h1>Processing Model of WeakRef and FinalizationRegistry Objects</h1>
+
+    <emu-note>
+      This section needs updating to incoprate weakly held symbols.
+    </emu-note>
+  </emu-clause>
+
+  <emu-clause id="sec-addtokeptobjects" type="abstract operation">
+    <h1>
+      AddToKeptObjects (
+        <del>_object_: an Object,</del>
+        <ins>_value_: an Object or a Symbol,</ins>
+      ): ~unused~
+    </h1>
+    <dl class="header">
+    </dl>
+    <emu-alg>
+      1. Let _agentRecord_ be the surrounding agent's Agent Record.
+      1. <del>Append _object_ to _agentRecord_.[[KeptAlive]].</del>
+      1. <ins>Append _value_ to _agentRecord_.[[KeptAlive]].</ins>
+      1. Return ~unused~.
+    </emu-alg>
+    <emu-note>
+      When the abstract operation AddToKeptObjects is called with a target object <ins>, or symbol,</ins> reference, it adds the target to a list that will point strongly at the target until ClearKeptObjects is called.
+    </emu-note>
   </emu-clause>
 </emu-clause>
+
 <emu-clause id="sec-canbeheldweakly-abstract-operation" type="abstract operation" aoid="CanBeHeldWeakly">
   <h1>
     CanBeHeldWeakly (
@@ -63,35 +61,18 @@ contributors:
     1. If Type(_v_) is Symbol, then
       1. For each element _e_ of the GlobalSymbolRegistry List (see <emu-xref href="#sec-symbol.for"></emu-xref>), do
         1. If SameValue(_e_.[[Symbol]], _v_) is *true*, return *false*.
-      1. Let _wellKnownSymbols_ be the symbols listed in <emu-xref href="#sec-well-known-symbols"></emu-xref>.
-      1. If _wellKnownSymbols_ contains _v_, return *false*.
       1. Else, return *true*.
     1. Return *false*.
   </emu-alg>
   <emu-note type=editor>
-    <p>This abstract operation determines if _v_ is considered to have a unique value being an Object or a Symbol. This enables _v_ to be a valid key of a WeakMap or entry in a weak collection, e.g. WeakSet, WeakRef, or FinalizationRegistry.</p>
-    <p>'Registered' and 'Well Known' symbols are not allowed to be observably held weakly, in a WeakSet for example, to provide simplicity for implementations that may collect them when their value is unreachable.</p>
+    <p>This abstract operation determines if _v_ is considered to have an identity suitable for a weak reference. i.e. Is _v_ a valid candidate key of a WeakMap, or entry in a WeakSet, or target of a WeakRef or FinalizationRegistry.</p>
+    <p>'Registered symbols' are not considered to have a suitable identity because their identity is similar to strings, and implementations may attempt to collect them when they are unreachable.</p>
+    <p>'Well-Known symbols' <emu-xref href="#sec-well-known-symbols"></emu-xref> are considered to have a suitable identity because there are a small finite number of them and implementations do not attempt to unobservably collect them.</p>
   </emu-note>
-</emu-clause>
-<emu-clause id="sec-%canbeheldweakly%">
-  <h1>%CanBeHeldWeakly%( _argument_ )</h1>
-  <p>The <dfn>%CanBeHeldWeakly%</dfn> intrinsic is an anonymous built-in function object that is defined once for each realm. When %CanBeHeldWeakly% is called with one argument _argument_ (an ECMAScript language value) the following steps are taken:</p>
-  <emu-alg>
-    1. Return ! CanBeHeldWeakly(_argument_).
-  </emu-alg>
-  <p>The value of the [[Extensible]] internal slot of a %CanBeHeldWeakly% function is *false*.</p>
-  <p>The *"length"* property of a %CanBeHeldWeakly% function has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
-  <p>The *"name"* property of a %CanBeHeldWeakly% function has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
 </emu-clause>
 
 <emu-clause id="sec-modifications-of-weakmap">
   <h1>Modifications to WeakMap</h1>
-
-  <emu-clause id="sec-weakmap.isValidKey">
-    <h1>WeakMap.isValidKey( _key_ )</h1>
-    <p>The initial value of the isValidKey property is the %CanBeHeldWeakly% intrinsic object.</p>
-    <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-  </emu-clause>
 
   <emu-clause id="sec-weakmap.prototype.delete">
     <h1>WeakMap.prototype.delete ( _key_ )</h1>
@@ -164,12 +145,6 @@ contributors:
 <emu-clause id="sec-modifications-of-weakset">
   <h1>Modifications to WeakSet</h1>
 
-  <emu-clause id="sec-weakset.isValidValue">
-    <h1>WeakSet.isValidValue( _value_ )</h1>
-    <p>The initial value of the isValidValue property is the %CanBeHeldWeakly% intrinsic object.</p>
-    <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-  </emu-clause>
-
   <emu-clause id="sec-weakset.prototype.add">
     <h1>WeakSet.prototype.add ( _value_ )</h1>
     <p>The following steps are taken:</p>
@@ -223,12 +198,6 @@ contributors:
 <emu-clause id="sec-modifications-of-weakref-finalization">
   <h1>Modifications to WeakRef and FinalizationRegistry</h1>
 
-  <emu-clause id="sec-weak-ref.isValidTarget">
-    <h1>WeakRef.isValidTarget( _target_ )</h1>
-    <p>The initial value of the isValidValue property is the %CanBeHeldWeakly% intrinsic object.</p>
-    <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-  </emu-clause>
-
   <emu-clause id="sec-weak-ref-target">
     <h1>WeakRef ( _target_ )</h1>
     <p>When the `WeakRef` function is called with argument _target_, the following steps are taken:</p>
@@ -241,12 +210,6 @@ contributors:
       1. Set _weakRef_.[[WeakRefTarget]] to _target_.
       1. Return _weakRef_.
     </emu-alg>
-  </emu-clause>
-
-  <emu-clause id="sec-finalization-registry.isValidTarget">
-    <h1>FinalizationRegistry.isValidTarget( _target_ )</h1>
-    <p>The initial value of the isValidTarget property is the %CanBeHeldWeakly% intrinsic object.</p>
-    <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
   </emu-clause>
 
   <emu-clause id="sec-finalization-registry.prototype.register">

--- a/spec.emu
+++ b/spec.emu
@@ -50,26 +50,38 @@ contributors:
     </emu-clause>
   </emu-clause>
 </emu-clause>
+<emu-clause id="sec-canbeheldweakly-abstract-operation" type="abstract operation">
+  <h1>
+    CanBeHeldWeakly (
+      _v_: unknown
+    ): a Boolean
+  </h1>
+  <dl class="header">
+  </dl>
+  <emu-alg>
+    1. If Type(_v_) is Object, return *true*.
+    1. If Type(_v_) is Symbol, then
+      1. For each element _e_ of the GlobalSymbolRegistry List (see <emu-xref href="#sec-symbol.for"></emu-xref>), do
+        1. If SameValue(_e_.[[Symbol]], _v_) is *true*, return *false*.
+      1. Let _wellKnownSymbols_ be the symbols listed in <emu-xref href="#sec-well-known-symbols"></emu-xref>.
+      1. If _wellKnownSymbols_ contains _v_, return *false*.
+      1. Else, return *true*.
+    1. Return *false*.
+  </emu-alg>
+  <emu-note type=editor>
+    <p>This abstract operation determines if _v_ is considered to have a unique value being an Object or a Symbol. This enables _v_ to be a valid key of a WeakMap or entry in a weak collection, e.g. WeakSet, WeakRef, or FinalizationRegistry.</p>
+    <p>'Registered' and 'Well Known' symbols are not allowed to be observably held weakly, in a WeakSet for example, to provide simplicity for implementations that may collect them when their value is unreachable.</p>
+  </emu-note>
+</emu-clause>
 <emu-clause id="sec-%canbeheldweakly%">
   <h1>%CanBeHeldWeakly%( _argument_ )</h1>
   <p>The <dfn>%CanBeHeldWeakly%</dfn> intrinsic is an anonymous built-in function object that is defined once for each realm. When %CanBeHeldWeakly% is called with one argument _argument_ (an ECMAScript language value) the following steps are taken:</p>
   <emu-alg>
-    1. If Type(_argument_) is Object, return *true*.
-    1. If Type(_argument_) is Symbol, then
-      1. For each element _e_ of the GlobalSymbolRegistry List (see <emu-xref href="#sec-symbol.for"></emu-xref>), do
-        1. If SameValue(_e_.[[Symbol]], _argument_) is *true*, return *false*.
-      1. Let _wellKnownSymbols_ be the symbols listed in <emu-xref href="#sec-well-known-symbols"></emu-xref>.
-      1. If _wellKnownSymbols_ contains _argument_, return *false*.
-      1. Else, return *true*.
-    1. Return *false*.
+    1. Return ! CanBeHeldWeakly(_argument_).
   </emu-alg>
   <p>The value of the [[Extensible]] internal slot of a %CanBeHeldWeakly% function is *false*.</p>
   <p>The *"length"* property of a %CanBeHeldWeakly% function has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
   <p>The *"name"* property of a %CanBeHeldWeakly% function has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
-  <emu-note type=editor>
-    <p>This abstract operation determines if _argument_ is considered to have a unique value being an Object or a Symbol. This enables _argument_ to be a valid key of a WeakMap or entry in a weak collection, e.g. WeakSet, WeakRef, or FinalizationRegistry.</p>
-    <p>'Registered' and 'Well Known' symbols are not allowed to be observably held weakly, in a WeakSet for example, to provide simplicity for implementations that may collect them when their value is unreachable.</p>
-  </emu-note>
 </emu-clause>
 
 <emu-clause id="sec-modifications-of-weakmap">
@@ -89,7 +101,7 @@ contributors:
       1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
       1. Let _entries_ be the List that is _M_.[[WeakMapData]].
       1. <del>If Type(_key_) is not Object, return *false*.</del>
-      1. <ins>If ! %CanBeHeldWeakly%(_key_) is *false*, return *false*.</ins>
+      1. <ins>If ! CanBeHeldWeakly(_key_) is *false*, return *false*.</ins>
       1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
         1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, then
           1. Set _p_.[[Key]] to ~empty~.
@@ -107,7 +119,7 @@ contributors:
       1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
       1. Let _entries_ be the List that is _M_.[[WeakMapData]].
       1. <del>If Type(_key_) is not Object, return *undefined*.</del>
-      1. <ins>If ! %CanBeHeldWeakly%(_key_) is *false*, return *undefined*.</ins>
+      1. <ins>If ! CanBeHeldWeakly(_key_) is *false*, return *undefined*.</ins>
       1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
         1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, return _p_.[[Value]].
       1. Return *undefined*.
@@ -122,7 +134,7 @@ contributors:
       1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
       1. Let _entries_ be the List that is _M_.[[WeakMapData]].
       1. <del>If Type(_key_) is not Object, return *false*.</del>
-      1. <ins>If ! %CanBeHeldWeakly%(_key_) is *false*, return *false*.</ins>
+      1. <ins>If ! CanBeHeldWeakly(_key_) is *false*, return *false*.</ins>
       1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
         1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, return *true*.
       1. Return *false*.
@@ -137,7 +149,7 @@ contributors:
       1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
       1. Let _entries_ be the List that is _M_.[[WeakMapData]].
       1. <del>If Type(_key_) is not Object, throw a *TypeError* exception.</del>
-      1. <ins>If ! %CanBeHeldWeakly%(_key_) is *false*, throw a *TypeError* exception.</ins>
+      1. <ins>If ! CanBeHeldWeakly(_key_) is *false*, throw a *TypeError* exception.</ins>
       1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
         1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, then
           1. Set _p_.[[Value]] to _value_.
@@ -153,7 +165,7 @@ contributors:
   <h1>Modifications to WeakSet</h1>
 
   <emu-clause id="sec-weakset.isValidValue">
-    <h1>WeakMap.isValidValue( _value_ )</h1>
+    <h1>WeakSet.isValidValue( _value_ )</h1>
     <p>The initial value of the isValidValue property is the %CanBeHeldWeakly% intrinsic object.</p>
     <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
   </emu-clause>
@@ -165,7 +177,7 @@ contributors:
       1. Let _S_ be the *this* value.
       1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
       1. <del>If Type(_value_) is not Object, throw a *TypeError* exception.</del>
-      1. <ins>If ! %CanBeHeldWeakly%(_value_) is *false*, throw a *TypeError* exception.</ins>
+      1. <ins>If ! CanBeHeldWeakly(_value_) is *false*, throw a *TypeError* exception.</ins>
       1. Let _entries_ be the List that is _S_.[[WeakSetData]].
       1. For each element _e_ of _entries_, do
         1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, then
@@ -182,7 +194,7 @@ contributors:
       1. Let _S_ be the *this* value.
       1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
       1. <del>If Type(_value_) is not Object, return *false*.</del>
-      1. <ins>If ! %CanBeHeldWeakly%(_value_) is *false*, return *false*.</ins>
+      1. <ins>If ! CanBeHeldWeakly(_value_) is *false*, return *false*.</ins>
       1. Let _entries_ be the List that is _S_.[[WeakSetData]].
       1. For each element _e_ of _entries_, do
         1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, then
@@ -200,7 +212,7 @@ contributors:
       1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
       1. Let _entries_ be the List that is _S_.[[WeakSetData]].
       1. <del>If Type(_value_) is not Object, return *false*.</del>
-      1. <ins>If ! %CanBeHeldWeakly%(_value_) is *false*, return *false*.</ins>
+      1. <ins>If ! CanBeHeldWeakly(_value_) is *false*, return *false*.</ins>
       1. For each element _e_ of _entries_, do
         1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, return *true*.
       1. Return *false*.
@@ -223,7 +235,7 @@ contributors:
     <emu-alg>
       1. If NewTarget is *undefined*, throw a *TypeError* exception.
       1. <del>If Type(_target_) is not Object, throw a *TypeError* exception.</del>
-      1. <ins>If ! %CanBeHeldWeakly%(_target_) is *false*, throw a *TypeError* exception.</ins>
+      1. <ins>If ! CanBeHeldWeakly(_target_) is *false*, throw a *TypeError* exception.</ins>
       1. Let _weakRef_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%WeakRef.prototype%"*, &laquo; [[WeakRefTarget]] &raquo;).
       1. Perform ! AddToKeptObjects(_target_).
       1. Set _weakRef_.[[WeakRefTarget]] to _target_.
@@ -244,10 +256,10 @@ contributors:
       1. Let _finalizationRegistry_ be the *this* value.
       1. Perform ? RequireInternalSlot(_finalizationRegistry_, [[Cells]]).
       1. <del>If Type(_target_) is not Object, throw a *TypeError* exception.</del>
-      1. <ins>If ! %CanBeHeldWeakly%(_target_) is *false*, throw a *TypeError* exception.</ins>
+      1. <ins>If ! CanBeHeldWeakly(_target_) is *false*, throw a *TypeError* exception.</ins>
       1. If SameValue(_target_, _heldValue_) is *true*, throw a *TypeError* exception.
       1. <del>If Type(_unregisterToken_) is not Object, then</del>
-      1. <ins>If ! %CanBeHeldWeakly%(_unregisterToken_) is *false*, then</ins>
+      1. <ins>If ! CanBeHeldWeakly(_unregisterToken_) is *false*, then</ins>
         1. If _unregisterToken_ is not *undefined*, throw a *TypeError* exception.
         1. Set _unregisterToken_ to ~empty~.
       1. Let _cell_ be the Record { [[WeakRefTarget]]: _target_, [[HeldValue]]: _heldValue_, [[UnregisterToken]]: _unregisterToken_ }.
@@ -263,7 +275,7 @@ contributors:
       1. Let _finalizationRegistry_ be the *this* value.
       1. Perform ? RequireInternalSlot(_finalizationRegistry_, [[Cells]]).
       1. <del>If Type(_unregisterToken_) is not Object, throw a *TypeError* exception.</del>
-      1. <ins>If ! %CanBeHeldWeakly%(_unregisterToken_) is *false*, throw a *TypeError* exception.</ins>
+      1. <ins>If ! CanBeHeldWeakly(_unregisterToken_) is *false*, throw a *TypeError* exception.</ins>
       1. Let _removed_ be *false*.
       1. For each Record { [[WeakRefTarget]], [[HeldValue]], [[UnregisterToken]] } _cell_ of _finalizationRegistry_.[[Cells]], do
         1. If _cell_.[[UnregisterToken]] is not ~empty~ and SameValue(_cell_.[[UnregisterToken]], _unregisterToken_) is *true*, then

--- a/spec.emu
+++ b/spec.emu
@@ -50,7 +50,7 @@ contributors:
     </emu-clause>
   </emu-clause>
 </emu-clause>
-<emu-clause id="sec-canbeheldweakly-abstract-operation" type="abstract operation">
+<emu-clause id="sec-canbeheldweakly-abstract-operation" type="abstract operation" aoid="CanBeHeldWeakly">
   <h1>
     CanBeHeldWeakly (
       _v_: unknown

--- a/spec.emu
+++ b/spec.emu
@@ -13,22 +13,73 @@ contributors:
   - Leo Balter
   - Caridy Patiño
   - Rick Waldron
+  - Ashley Claymore
 </pre>
 
-<emu-clause id="sec-isobjectorsymbol" aoid="IsObjectOrSymbol">
-  <h1>IsObjectOrSymbol ( _argument_ )</h1>
-  <p>The abstract operation IsObjectOrSymbol takes argument _argument_ (an ECMAScript language value) and determines if its Type is Object or Symbol. This operation performs the following steps when called:</p>
+<emu-clause id="sec-ecmascript-data-types-and-values" aoid="Type">
+  <h1>ECMAScript Data Types and Values</h1>
+  <emu-clause id="sec-object-type">
+    <h1>The Object Type</h1>
+    <emu-clause id="sec-well-known-intrinsic-objects">
+      <h1>Well-Known Intrinsic Objects</h1>
+      <emu-table id="table-well-known-intrinsic-objects" caption="Well-Known Intrinsic Objects" oldids="table-7">
+        <table>
+          <tr>
+            <th>
+              Intrinsic Name
+            </th>
+            <th>
+              Global Name
+            </th>
+            <th>
+              ECMAScript Language Association
+            </th>
+          </tr>
+          <tr>
+            <td>
+              <ins>%CanBeHeldWeakly%</ins>
+            </td>
+            <td>
+            </td>
+            <td>
+              <ins>A function to check if a value can be held weakly (<emu-xref href="#sec-%canbeheldweakly%"></emu-xref>)</ins>
+            </td>
+          </tr>
+        </table>
+      </emu-table>
+    </emu-clause>
+  </emu-clause>
+</emu-clause>
+<emu-clause id="sec-%canbeheldweakly%">
+  <h1>%CanBeHeldWeakly%( _argument_ )</h1>
+  <p>The <dfn>%CanBeHeldWeakly%</dfn> intrinsic is an anonymous built-in function object that is defined once for each realm. When %CanBeHeldWeakly% is called with one argument _argument_ (an ECMAScript language value) the following steps are taken:</p>
   <emu-alg>
-    1. If Type(_argument_) is Object or Symbol, return *true*.
+    1. If Type(_argument_) is Object, return *true*.
+    1. If Type(_argument_) is Symbol, then
+      1. For each element _e_ of the GlobalSymbolRegistry List (see <emu-xref href="#sec-symbol.for"></emu-xref>), do
+        1. If SameValue(_e_.[[Symbol]], _argument_) is *true*, return *false*.
+      1. Let _wellKnownSymbols_ be the symbols listed in <emu-xref href="#sec-well-known-symbols"></emu-xref>.
+      1. If _wellKnownSymbols_ contains _argument_, return *false*.
+      1. Else, return *true*.
     1. Return *false*.
   </emu-alg>
+  <p>The value of the [[Extensible]] internal slot of a %CanBeHeldWeakly% function is *false*.</p>
+  <p>The *"length"* property of a %CanBeHeldWeakly% function has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+  <p>The *"name"* property of a %CanBeHeldWeakly% function has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
   <emu-note type=editor>
     <p>This abstract operation determines if _argument_ is considered to have a unique value being an Object or a Symbol. This enables _argument_ to be a valid key of a WeakMap or entry in a weak collection, e.g. WeakSet, WeakRef, or FinalizationRegistry.</p>
+    <p>'Registered' and 'Well Known' symbols are not allowed to be observably held weakly, in a WeakSet for example, to provide simplicity for implementations that may collect them when their value is unreachable.</p>
   </emu-note>
 </emu-clause>
 
 <emu-clause id="sec-modifications-of-weakmap">
-  <h1>Modifications to the properties of WeakMap.prototype</h1>
+  <h1>Modifications to WeakMap</h1>
+
+  <emu-clause id="sec-weakmap.isValidKey">
+    <h1>WeakMap.isValidKey( _key_ )</h1>
+    <p>The initial value of the isValidKey property is the %CanBeHeldWeakly% intrinsic object.</p>
+    <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+  </emu-clause>
 
   <emu-clause id="sec-weakmap.prototype.delete">
     <h1>WeakMap.prototype.delete ( _key_ )</h1>
@@ -38,7 +89,7 @@ contributors:
       1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
       1. Let _entries_ be the List that is _M_.[[WeakMapData]].
       1. <del>If Type(_key_) is not Object, return *false*.</del>
-      1. <ins>If IsObjectOrSymbol(_key_) is *false*, return *false*.</ins>
+      1. <ins>If ! %CanBeHeldWeakly%(_key_) is *false*, return *false*.</ins>
       1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
         1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, then
           1. Set _p_.[[Key]] to ~empty~.
@@ -56,7 +107,7 @@ contributors:
       1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
       1. Let _entries_ be the List that is _M_.[[WeakMapData]].
       1. <del>If Type(_key_) is not Object, return *undefined*.</del>
-      1. <ins>If IsObjectOrSymbol(_key_) is *false*, return *undefined*.</ins>
+      1. <ins>If ! %CanBeHeldWeakly%(_key_) is *false*, return *undefined*.</ins>
       1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
         1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, return _p_.[[Value]].
       1. Return *undefined*.
@@ -71,7 +122,7 @@ contributors:
       1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
       1. Let _entries_ be the List that is _M_.[[WeakMapData]].
       1. <del>If Type(_key_) is not Object, return *false*.</del>
-      1. <ins>If IsObjectOrSymbol(_key_) is *false*, return *false*.</ins>
+      1. <ins>If ! %CanBeHeldWeakly%(_key_) is *false*, return *false*.</ins>
       1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
         1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, return *true*.
       1. Return *false*.
@@ -86,7 +137,7 @@ contributors:
       1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
       1. Let _entries_ be the List that is _M_.[[WeakMapData]].
       1. <del>If Type(_key_) is not Object, throw a *TypeError* exception.</del>
-      1. <ins>If IsObjectOrSymbol(_key_) is *false*, throw a *TypeError* exception.</ins>
+      1. <ins>If ! %CanBeHeldWeakly%(_key_) is *false*, throw a *TypeError* exception.</ins>
       1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
         1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, then
           1. Set _p_.[[Value]] to _value_.
@@ -99,7 +150,13 @@ contributors:
 </emu-clause>
 
 <emu-clause id="sec-modifications-of-weakset">
-  <h1>Modifications to the properties of WeakSet.prototype</h1>
+  <h1>Modifications to WeakSet</h1>
+
+  <emu-clause id="sec-weakset.isValidValue">
+    <h1>WeakMap.isValidValue( _value_ )</h1>
+    <p>The initial value of the isValidValue property is the %CanBeHeldWeakly% intrinsic object.</p>
+    <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+  </emu-clause>
 
   <emu-clause id="sec-weakset.prototype.add">
     <h1>WeakSet.prototype.add ( _value_ )</h1>
@@ -108,7 +165,7 @@ contributors:
       1. Let _S_ be the *this* value.
       1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
       1. <del>If Type(_value_) is not Object, throw a *TypeError* exception.</del>
-      1. <ins>If IsObjectOrSymbol(_value_) is *false*, throw a *TypeError* exception.</ins>
+      1. <ins>If ! %CanBeHeldWeakly%(_value_) is *false*, throw a *TypeError* exception.</ins>
       1. Let _entries_ be the List that is _S_.[[WeakSetData]].
       1. For each element _e_ of _entries_, do
         1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, then
@@ -125,7 +182,7 @@ contributors:
       1. Let _S_ be the *this* value.
       1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
       1. <del>If Type(_value_) is not Object, return *false*.</del>
-      1. <ins>If IsObjectOrSymbol(_value_) is *false*, return *false*.</ins>
+      1. <ins>If ! %CanBeHeldWeakly%(_value_) is *false*, return *false*.</ins>
       1. Let _entries_ be the List that is _S_.[[WeakSetData]].
       1. For each element _e_ of _entries_, do
         1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, then
@@ -143,7 +200,7 @@ contributors:
       1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
       1. Let _entries_ be the List that is _S_.[[WeakSetData]].
       1. <del>If Type(_value_) is not Object, return *false*.</del>
-      1. <ins>If IsObjectOrSymbol(_value_) is *false*, return *false*.</ins>
+      1. <ins>If ! %CanBeHeldWeakly%(_value_) is *false*, return *false*.</ins>
       1. For each element _e_ of _entries_, do
         1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, return *true*.
       1. Return *false*.
@@ -153,18 +210,31 @@ contributors:
 
 <emu-clause id="sec-modifications-of-weakref-finalization">
   <h1>Modifications to WeakRef and FinalizationRegistry</h1>
+
+  <emu-clause id="sec-weak-ref.isValidTarget">
+    <h1>WeakRef.isValidTarget( _target_ )</h1>
+    <p>The initial value of the isValidValue property is the %CanBeHeldWeakly% intrinsic object.</p>
+    <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+  </emu-clause>
+
   <emu-clause id="sec-weak-ref-target">
     <h1>WeakRef ( _target_ )</h1>
     <p>When the `WeakRef` function is called with argument _target_, the following steps are taken:</p>
     <emu-alg>
       1. If NewTarget is *undefined*, throw a *TypeError* exception.
       1. <del>If Type(_target_) is not Object, throw a *TypeError* exception.</del>
-      1. <ins>If IsObjectOrSymbol(_target_) is *false*, throw a *TypeError* exception.</ins>
+      1. <ins>If ! %CanBeHeldWeakly%(_target_) is *false*, throw a *TypeError* exception.</ins>
       1. Let _weakRef_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%WeakRef.prototype%"*, &laquo; [[WeakRefTarget]] &raquo;).
       1. Perform ! AddToKeptObjects(_target_).
       1. Set _weakRef_.[[WeakRefTarget]] to _target_.
       1. Return _weakRef_.
     </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="sec-finalization-registry.isValidTarget">
+    <h1>FinalizationRegistry.isValidTarget( _target_ )</h1>
+    <p>The initial value of the isValidTarget property is the %CanBeHeldWeakly% intrinsic object.</p>
+    <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
   </emu-clause>
 
   <emu-clause id="sec-finalization-registry.prototype.register">
@@ -174,10 +244,10 @@ contributors:
       1. Let _finalizationRegistry_ be the *this* value.
       1. Perform ? RequireInternalSlot(_finalizationRegistry_, [[Cells]]).
       1. <del>If Type(_target_) is not Object, throw a *TypeError* exception.</del>
-      1. <ins>If IsObjectOrSymbol(_target_) is *false*, throw a *TypeError* exception.</ins>
+      1. <ins>If ! %CanBeHeldWeakly%(_target_) is *false*, throw a *TypeError* exception.</ins>
       1. If SameValue(_target_, _heldValue_) is *true*, throw a *TypeError* exception.
       1. <del>If Type(_unregisterToken_) is not Object, then</del>
-      1. <ins>If IsObjectOrSymbol(_unregisterToken_) is *false*, then</ins>
+      1. <ins>If ! %CanBeHeldWeakly%(_unregisterToken_) is *false*, then</ins>
         1. If _unregisterToken_ is not *undefined*, throw a *TypeError* exception.
         1. Set _unregisterToken_ to ~empty~.
       1. Let _cell_ be the Record { [[WeakRefTarget]]: _target_, [[HeldValue]]: _heldValue_, [[UnregisterToken]]: _unregisterToken_ }.
@@ -193,7 +263,7 @@ contributors:
       1. Let _finalizationRegistry_ be the *this* value.
       1. Perform ? RequireInternalSlot(_finalizationRegistry_, [[Cells]]).
       1. <del>If Type(_unregisterToken_) is not Object, throw a *TypeError* exception.</del>
-      1. <ins>If IsObjectOrSymbol(_unregisterToken_) is *false*, throw a *TypeError* exception.</ins>
+      1. <ins>If ! %CanBeHeldWeakly%(_unregisterToken_) is *false*, throw a *TypeError* exception.</ins>
       1. Let _removed_ be *false*.
       1. For each Record { [[WeakRefTarget]], [[HeldValue]], [[UnregisterToken]] } _cell_ of _finalizationRegistry_.[[Cells]], do
         1. If _cell_.[[UnregisterToken]] is not ~empty~ and SameValue(_cell_.[[UnregisterToken]], _unregisterToken_) is *true*, then

--- a/spec.emu
+++ b/spec.emu
@@ -72,7 +72,7 @@ contributors:
 </emu-clause>
 
 <emu-clause id="sec-modifications-of-weakmap">
-  <h1>Modifications to WeakMap</h1>
+  <h1>Modifications to the properties of WeakMap.prototype</h1>
 
   <emu-clause id="sec-weakmap.prototype.delete">
     <h1>WeakMap.prototype.delete ( _key_ )</h1>
@@ -143,7 +143,7 @@ contributors:
 </emu-clause>
 
 <emu-clause id="sec-modifications-of-weakset">
-  <h1>Modifications to WeakSet</h1>
+  <h1>Modifications to the properties of WeakSet.prototype</h1>
 
   <emu-clause id="sec-weakset.prototype.add">
     <h1>WeakSet.prototype.add ( _value_ )</h1>


### PR DESCRIPTION
Made a start on what the spec text changes could be if _registered_ and _well-known_ symbols were not allowed in `WeakMap`, `WeakSet`, `WeakRef` and `FinalizationRegistry`

Closes #21 
